### PR TITLE
Add requestOptions (proxy support + more)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,17 @@ const binanceRest = new api.BinanceRest({
      * Optional, default is false. Binance's API returns objects with lots of one letter keys.  By
      * default those keys will be replaced with more descriptive, longer ones.
      */
-    handleDrift: false
+    handleDrift: false,
     /* Optional, default is false.  If turned on, the library will attempt to handle any drift of
      * your clock on it's own.  If a request fails due to drift, it'll attempt a fix by requesting
      * binance's server time, calculating the difference with your own clock, and then reattempting
      * the request.
+     */
+    requestOptions: {}
+    /*
+     * Options as supported by the 'request' library
+     * For a list of available options, see:
+     * https://github.com/request/request
      */
 });
 

--- a/lib/rest.js
+++ b/lib/rest.js
@@ -13,7 +13,8 @@ class BinanceRest {
         recvWindow = false,
         timeout = 15000,
         disableBeautification = false,
-        handleDrift = false
+        handleDrift = false,
+        requestOptions = {}
     }) {
         this.key = key;
         this.secret = secret;
@@ -21,6 +22,7 @@ class BinanceRest {
         this.timeout = timeout;
         this.disableBeautification = disableBeautification;
         this.handleDrift = handleDrift;
+        this.requestOptions = requestOptions;
 
         this._beautifier = new Beautifier();
         this._baseUrl = 'https://api.binance.com/';
@@ -34,10 +36,10 @@ class BinanceRest {
 
         let queryString;
         const type = _.last(route.split('/')),
-            options = {
+            options = Object.assign({
                 url: `${this._baseUrl}${route}`,
                 timeout: this.timeout
-            };
+            }, this.requestOptions);
 
         if (security === 'SIGNED') {
             if (this.recvWindow) {


### PR DESCRIPTION
Solves https://github.com/zoeyg/binance/issues/58; one can now configure a proxy by doing:

```
new BinanceRest({
    ...,
    requestOptions: {
        proxy: 'http://myproxy:3128'
    }
});
```