### PR TITLE
Strip out processFilter workflows from #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,31 @@ Responses
 }
 ```
 
+# Processing
+
+## Filters
+
+Quantities and prices used when creating orders must fall within the guidelines provided by the
+filters in symbolInfo responses. The code below shows how to turn a quantity and price into
+acceptable values for creating an order. The results vary depending on the symbol used, since
+different symbols have different filters.
+
+Symbol information can be obtained from **[exchangeInfo([callback _funcion_])](https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md#exchange-information)**
+
+```js
+const { ValueProcessor } = require('binance');
+
+ValueProcessor.processFilters(symbolInfo, {
+    quantity: '30.000000001', // Also accepts 'number' values.
+    price: '0.00234414211'
+})
+
+// {
+//     quantity: '30.000',
+//     price: '0.002344'
+// }
+```
+
 # Timestamp errors
 
 Most can be resolved by adjusting your `recvWindow` a bit larger, but if your clock is constantly

--- a/lib/binance.js
+++ b/lib/binance.js
@@ -1,4 +1,5 @@
 module.exports = {
     BinanceRest: require('./rest.js'),
-    BinanceWS: require('./ws.js')
+    BinanceWS: require('./ws.js'),
+    ValueProcessor: require('./processor.js')
 };

--- a/lib/processor.js
+++ b/lib/processor.js
@@ -1,0 +1,72 @@
+const number = require('bignumber.js');
+
+module.exports = {
+    processFilters(symbolInfo,
+        { quantity, price },
+        { priceRounding = 'ROUND_HALF_UP', quantityRounding = 'ROUND_DOWN' } = {}) {
+
+        if (typeof price === 'number') {
+            price = price.toFixed(8);
+        }
+        if (typeof quantity === 'number') {
+            quantity = quantity.toFixed(8);
+        }
+
+        let priceFilter = symbolInfo.filters.filter(f => f.filterType === 'PRICE_FILTER')[0];
+        if (priceFilter) {
+            const { minPrice, maxPrice, tickSize } = priceFilter;
+            const dp = number(tickSize).dp();
+            if (number(price).lt(minPrice)) {
+                price = minPrice;
+            }
+            if (number(price).gt(maxPrice)) {
+                price = maxPrice;
+            }
+            const mod = number(price).mod(tickSize);
+            price = number(price).minus(mod)
+                .toFixed(dp, number[priceRounding]);
+        }
+
+        let lotSizeFilter = symbolInfo.filters.filter(f => f.filterType === 'LOT_SIZE')[0];
+        if (lotSizeFilter) {
+            const { minQty, maxQty, stepSize } = lotSizeFilter;
+            const dp = number(stepSize).dp();
+            if (number(quantity).lt(minQty)) {
+                quantity = minQty;
+            }
+            if (number(quantity).gt(maxQty)) {
+                quantity = maxQty;
+            }
+
+            let minNotionalFilter = symbolInfo.filters.filter(f => f.filterType === 'MIN_NOTIONAL')[0];
+            if (minNotionalFilter) {
+                if (number(quantity).times(price)
+                    .lt(minNotionalFilter.minNotional)) {
+                    // Always round up for minNotional since we can't be below it.
+                    quantity = number(minNotionalFilter.minNotional).div(price)
+                        .toFixed(dp, number.ROUND_UP);
+
+                    const mod = number(quantity).mod(stepSize);
+                    if (mod.gt(0)) {
+                        quantity = number(quantity)
+                            .plus(stepSize)
+                            .minus(mod)
+                            .toFixed(dp, number[quantityRounding]);
+                    }
+                }
+            }
+
+            const mod = number(quantity).mod(stepSize);
+            quantity = number(quantity)
+                .minus(mod)
+                .toFixed(dp, number[quantityRounding]);
+
+            quantity = number(quantity).toFixed(dp, number[quantityRounding]);
+        }
+
+        return {
+            quantity,
+            price
+        };
+    }
+};

--- a/test/processor-tests.js
+++ b/test/processor-tests.js
@@ -1,0 +1,295 @@
+const { expect } = require('chai');
+
+describe('processing', () => {
+    const ValueProcessor = require('../lib/processor');
+    const { processFilters } = ValueProcessor;
+
+    it('is exposed out the package', () => {
+        const binance = require('../lib/binance');
+        expect(ValueProcessor).to.equal(binance.ValueProcessor);
+    });
+
+    describe('processFilters', () => {
+        const symbolInfo1 = {
+            'symbol': 'ETHBTC',
+            'status': 'TRADING',
+            'baseAsset': 'ETH',
+            'baseAssetPrecision': 8,
+            'quoteAsset': 'BTC',
+            'quotePrecision': 8,
+            'orderTypes': ['LIMIT', 'LIMIT_MAKER', 'MARKET', 'STOP_LOSS_LIMIT', 'TAKE_PROFIT_LIMIT'],
+            'icebergAllowed': true,
+            'filters': [
+                {
+                    'filterType': 'PRICE_FILTER',
+                    'minPrice': '0.00000100',
+                    'maxPrice': '100000.00000000',
+                    'tickSize': '0.00000100'
+                }, {
+                    'filterType': 'LOT_SIZE',
+                    'minQty': '0.00100000',
+                    'maxQty': '100000.00000000',
+                    'stepSize': '0.00100000'
+                }, { 'filterType': 'MIN_NOTIONAL', 'minNotional': '0.00100000' }
+            ]
+        };
+
+        it('fixes quantities which are below the min lot size', () => {
+            expect(processFilters(symbolInfo1, {
+                quantity: 0.0001,
+                price: 1
+            })).to.deep.equal({
+                quantity: '0.001',
+                price: '1.000000'
+            });
+        });
+        it('fixes quantities which are above the max lot size', () => {
+            expect(processFilters(symbolInfo1, {
+                quantity: 1000000000,
+                price: 1
+            })).to.deep.equal({
+                quantity: '100000.000',
+                price: '1.000000'
+            });
+        });
+        it('fixes quantities based on step size ending with 1', () => {
+            expect(processFilters(symbolInfo1, {
+                quantity: 1,
+                price: 1
+            })).to.deep.equal({
+                quantity: '1.000',
+                price: '1.000000'
+            });
+            expect(processFilters(symbolInfo1, {
+                quantity: '1.0001',
+                price: '1.000000'
+            })).to.deep.equal({
+                quantity: '1.000',
+                price: '1.000000'
+            });
+            expect(processFilters(symbolInfo1, {
+                quantity: '1.0009',
+                price: '1.000000'
+            })).to.deep.equal({
+                quantity: '1.000',
+                price: '1.000000'
+            });
+            expect(processFilters(symbolInfo1, {
+                quantity: '1.001',
+                price: '1.000000'
+            })).to.deep.equal({
+                quantity: '1.001',
+                price: '1.000000'
+            });
+            expect(processFilters(symbolInfo1, {
+                quantity: '0.9999',
+                price: '1.000000'
+            })).to.deep.equal({
+                quantity: '0.999',
+                price: '1.000000'
+            });
+
+        });
+
+        it('fixes prices which are below the min price', () => {
+            expect(processFilters(symbolInfo1, {
+                quantity: '5000.000',
+                price: '0.000000000001'
+            })).to.deep.equal({
+                quantity: '5000.000',
+                price: '0.000001'
+            });
+        });
+        it('fixes prices which are above the max price', () => {
+            expect(processFilters(symbolInfo1, {
+                quantity: 1,
+                price: 1000000000
+            })).to.deep.equal({
+                quantity: '1.000',
+                price: '100000.000000'
+            });
+        });
+        it('fixes prices based on step size ending with 1', () => {
+            expect(processFilters(symbolInfo1, {
+                quantity: '1',
+                price: '1.000001'
+            })).to.deep.equal({
+                quantity: '1.000',
+                price: '1.000001'
+            });
+            expect(processFilters(symbolInfo1, {
+                quantity: '1',
+                price: '1.0000011'
+            })).to.deep.equal({
+                quantity: '1.000',
+                price: '1.000001'
+            });
+            expect(processFilters(symbolInfo1, {
+                quantity: '1',
+                price: '1.0000011'
+            })).to.deep.equal({
+                quantity: '1.000',
+                price: '1.000001'
+            });
+            expect(processFilters(symbolInfo1, {
+                quantity: '1',
+                price: '1.0000019'
+            })).to.deep.equal({
+                quantity: '1.000',
+                price: '1.000001'
+            });
+            expect(processFilters(symbolInfo1, {
+                quantity: '1',
+                price: '1.0000019'
+            }, { priceRounding: 'ROUND_DOWN' })).to.deep.equal({
+                quantity: '1.000',
+                price: '1.000001'
+            });
+        });
+        it('fixes quantity and price when below the min notional', () => {
+            expect(processFilters(symbolInfo1, {
+                quantity: '.00000001',
+                price: '1.000000'
+            })).to.deep.equal({
+                quantity: '0.001',
+                price: '1.000000'
+            });
+            expect(processFilters(symbolInfo1, {
+                quantity: '.00000001',
+                price: '0.500000'
+            })).to.deep.equal({
+                quantity: '0.002',
+                price: '0.500000'
+            });
+            expect(processFilters(symbolInfo1, {
+                quantity: '.00000001',
+                price: '0.000125'
+            })).to.deep.equal({
+                quantity: '8.000',
+                price: '0.000125'
+            });
+        });
+
+        const symbolInfo2 = {
+            'symbol': 'ETHBTC',
+            'status': 'TRADING',
+            'baseAsset': 'ETH',
+            'baseAssetPrecision': 8,
+            'quoteAsset': 'BTC',
+            'quotePrecision': 8,
+            'orderTypes': ['LIMIT', 'LIMIT_MAKER', 'MARKET', 'STOP_LOSS_LIMIT', 'TAKE_PROFIT_LIMIT'],
+            'icebergAllowed': true,
+            'filters': [
+                {
+                    'filterType': 'PRICE_FILTER',
+                    'minPrice': '0.00000300',
+                    'maxPrice': '100000.00000000',
+                    'tickSize': '0.00000300'
+                }, {
+                    'filterType': 'LOT_SIZE',
+                    'minQty': '0.00300000',
+                    'maxQty': '100000.00000000',
+                    'stepSize': '0.00300000'
+                }, { 'filterType': 'MIN_NOTIONAL', 'minNotional': '0.00100000' }
+            ]
+        };
+
+        it('fixes quantities based on step size ending with something other than 1', () => {
+            expect(processFilters(symbolInfo2, {
+                quantity: 1,
+                price: 1
+            })).to.deep.equal({
+                quantity: '0.999',
+                price: '0.999999'
+            });
+            expect(processFilters(symbolInfo2, {
+                quantity: '1.0001',
+                price: '1.000000'
+            })).to.deep.equal({
+                quantity: '0.999',
+                price: '0.999999'
+            });
+            expect(processFilters(symbolInfo2, {
+                quantity: '1.0009',
+                price: '1.000001'
+            })).to.deep.equal({
+                quantity: '0.999',
+                price: '0.999999'
+            });
+            expect(processFilters(symbolInfo2, {
+                quantity: '1.001',
+                price: '1.000000'
+            })).to.deep.equal({
+                quantity: '0.999',
+                price: '0.999999'
+            });
+            expect(processFilters(symbolInfo2, {
+                quantity: '0.9999',
+                price: '1.000000'
+            })).to.deep.equal({
+                quantity: '0.999',
+                price: '0.999999'
+            });
+        });
+        it('fixes prices based on step size ending with something other than 1', () => {
+            expect(processFilters(symbolInfo2, {
+                quantity: '1',
+                price: '1.000001'
+            })).to.deep.equal({
+                quantity: '0.999',
+                price: '0.999999'
+            });
+            expect(processFilters(symbolInfo2, {
+                quantity: '1',
+                price: '1.0000011'
+            })).to.deep.equal({
+                quantity: '0.999',
+                price: '0.999999'
+            });
+            expect(processFilters(symbolInfo2, {
+                quantity: '1',
+                price: '1.0000011'
+            })).to.deep.equal({
+                quantity: '0.999',
+                price: '0.999999'
+            });
+            expect(processFilters(symbolInfo2, {
+                quantity: '1',
+                price: '1.0000019'
+            })).to.deep.equal({
+                quantity: '0.999',
+                price: '0.999999'
+            });
+            expect(processFilters(symbolInfo2, {
+                quantity: '1',
+                price: '1.0000019'
+            }, { priceRounding: 'ROUND_DOWN' })).to.deep.equal({
+                quantity: '0.999',
+                price: '0.999999'
+            });
+        });
+        it('fixes quantity and price when below the min notional, with step size not ending with 1', () => {
+            expect(processFilters(symbolInfo2, {
+                quantity: '.00000001',
+                price: '1.000000'
+            })).to.deep.equal({
+                quantity: '0.003',
+                price: '0.999999'
+            });
+            expect(processFilters(symbolInfo2, {
+                quantity: '.00000004',
+                price: '0.150000'
+            })).to.deep.equal({
+                quantity: '0.009',
+                price: '0.150000'
+            });
+            expect(processFilters(symbolInfo2, {
+                quantity: '.00000001',
+                price: '0.000125'
+            })).to.deep.equal({
+                quantity: '8.133',
+                price: '0.000123'
+            });
+        });
+    });
+});


### PR DESCRIPTION
@apexearth did a great job making a processFilters utility function to adhere with Binance's number formatting & lot size rules. Unfortunately the original PR (#43) carries unrelated changes and seems to have gone stale.

This PR has these processFilters stripped out from #43 - without the unrelated websocket changes.