### PR TITLE
Clear onUserData keep alive interval if new user data socket opens or previous one is invalid. Fixes #70.

### DIFF
--- a/lib/rest.js
+++ b/lib/rest.js
@@ -30,7 +30,7 @@ class BinanceRest {
         if ('/' != this._baseUrl.substr(-1)) {
             this._baseUrl += '/';
         }
-      
+
         this._drift = 0;
         this._syncInterval = 0;
     }

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -2,6 +2,10 @@ const WebSocket = require('ws');
 const Beautifier = require('./beautifier.js');
 const _ = require('underscore');
 
+const BinanceErrors = Object.freeze({
+    INVALID_LISTEN_KEY: -1125
+});
+
 class BinanceWS {
     constructor(beautify = true) {
         this._baseUrl = 'wss://stream.binance.com:9443/ws/';
@@ -23,7 +27,10 @@ class BinanceWS {
         };
 
         // Reference to the setInterval timer for sending keep alive requests in onUserData
-        this.userDataRefreshIntervalId;
+        this._userDataRefresh = {
+            intervaId: false,
+            failCount: 0
+        };
     }
 
     _setupWebSocket(eventHandler, path, isCombined) {
@@ -73,30 +80,35 @@ class BinanceWS {
     }
 
     _clearUserDataInterval() {
-        this.userDataRefreshIntervalId &&
-            clearInterval(this.userDataRefreshIntervalId);
-        this.userDataRefreshIntervalId = false;
+        if (this._userDataRefresh.intervaId) {
+            clearInterval(this._userDataRefresh.intervaId);
+        }
+
+        this._userDataRefresh.intervaId = false;
+        this._userDataRefresh.failCount = 0;
     }
 
     _sendUserDataKeepAlive(binanceRest, response) {
         return binanceRest.keepAliveUserDataStream(response).catch(e => {
-            this.userDataRefreshIntervalId.failCount++;
+            this._userDataRefresh.failCount++;
             const msg =
                 'Failed requesting keepAliveUserDataStream for onUserData listener';
-            if (e && e.code === -1125) {
+            if (e && e.code === BinanceErrors.INVALID_LISTEN_KEY) {
                 console.error(
                     new Date(),
-                    msg + ' listen key expired - clearing keepAlive interval',
+                    msg,
+                    'listen key expired - clearing keepAlive interval',
                     e
                 );
-                return this._clearUserDataInterval();
+                this._clearUserDataInterval();
+                return;
             }
-            return console.error(
+            console.error(
                 new Date(),
                 msg,
-                e,
                 'failCount: ',
-                this.userDataRefreshIntervalId.failCount
+                this._userDataRefresh.failCount,
+                e
             );
         });
     }
@@ -141,11 +153,11 @@ class BinanceWS {
     onUserData(binanceRest, eventHandler, interval = 60000) {
         this._clearUserDataInterval();
         return binanceRest.startUserDataStream().then(response => {
-            this.userDataRefreshIntervalId = setInterval(
+            this._userDataRefresh.intervaId = setInterval(
                 () => this._sendUserDataKeepAlive(binanceRest, response),
                 interval
             );
-            this.userDataRefreshIntervalId.failCount = 0;
+            this._userDataRefresh.failCount = 0;
 
             return this._setupWebSocket(eventHandler, response.listenKey);
         });

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -3,7 +3,6 @@ const Beautifier = require('./beautifier.js');
 const _ = require('underscore');
 
 class BinanceWS {
-
     constructor(beautify = true) {
         this._baseUrl = 'wss://stream.binance.com:9443/ws/';
         this._combinedBaseUrl = 'wss://stream.binance.com:9443/stream?streams=';
@@ -12,12 +11,14 @@ class BinanceWS {
         this._beautify = beautify;
 
         this.streams = {
-            depth: (symbol) => `${symbol.toLowerCase()}@depth`,
-            depthLevel: (symbol, level) => `${symbol.toLowerCase()}@depth${level}`,
-            kline: (symbol, interval) => `${symbol.toLowerCase()}@kline_${interval}`,
-            aggTrade: (symbol) => `${symbol.toLowerCase()}@aggTrade`,
-            trade: (symbol) => `${symbol.toLowerCase()}@trade`,
-            ticker: (symbol) => `${symbol.toLowerCase()}@ticker`,
+            depth: symbol => `${symbol.toLowerCase()}@depth`,
+            depthLevel: (symbol, level) =>
+                `${symbol.toLowerCase()}@depth${level}`,
+            kline: (symbol, interval) =>
+                `${symbol.toLowerCase()}@kline_${interval}`,
+            aggTrade: symbol => `${symbol.toLowerCase()}@aggTrade`,
+            trade: symbol => `${symbol.toLowerCase()}@trade`,
+            ticker: symbol => `${symbol.toLowerCase()}@ticker`,
             allTickers: () => '!ticker@arr'
         };
 
@@ -72,19 +73,31 @@ class BinanceWS {
     }
 
     _clearUserDataInterval() {
-        this.userDataRefreshIntervalId && clearInterval(this.userDataRefreshIntervalId);
+        this.userDataRefreshIntervalId &&
+            clearInterval(this.userDataRefreshIntervalId);
         this.userDataRefreshIntervalId = false;
     }
 
     _sendUserDataKeepAlive(binanceRest, response) {
         return binanceRest.keepAliveUserDataStream(response).catch(e => {
             this.userDataRefreshIntervalId.failCount++;
-            const msg = 'Failed requesting keepAliveUserDataStream for onUserData listener';
+            const msg =
+                'Failed requesting keepAliveUserDataStream for onUserData listener';
             if (e && e.code === -1125) {
-                console.error(new Date(), msg + ' listen key expired - clearing keepAlive interval', e);
+                console.error(
+                    new Date(),
+                    msg + ' listen key expired - clearing keepAlive interval',
+                    e
+                );
                 return this._clearUserDataInterval();
             }
-            return console.error(new Date(), msg, e, 'failCount: ', this.userDataRefreshIntervalId.failCount);
+            return console.error(
+                new Date(),
+                msg,
+                e,
+                'failCount: ',
+                this.userDataRefreshIntervalId.failCount
+            );
         });
     }
 
@@ -93,15 +106,24 @@ class BinanceWS {
     }
 
     onDepthLevelUpdate(symbol, level, eventHandler) {
-        return this._setupWebSocket(eventHandler, this.streams.depthLevel(symbol, level));
+        return this._setupWebSocket(
+            eventHandler,
+            this.streams.depthLevel(symbol, level)
+        );
     }
 
     onKline(symbol, interval, eventHandler) {
-        return this._setupWebSocket(eventHandler, this.streams.kline(symbol, interval));
+        return this._setupWebSocket(
+            eventHandler,
+            this.streams.kline(symbol, interval)
+        );
     }
 
     onAggTrade(symbol, eventHandler) {
-        return this._setupWebSocket(eventHandler, this.streams.aggTrade(symbol));
+        return this._setupWebSocket(
+            eventHandler,
+            this.streams.aggTrade(symbol)
+        );
     }
 
     onTrade(symbol, eventHandler) {
@@ -119,7 +141,10 @@ class BinanceWS {
     onUserData(binanceRest, eventHandler, interval = 60000) {
         this._clearUserDataInterval();
         return binanceRest.startUserDataStream().then(response => {
-            this.userDataRefreshIntervalId = setInterval(() => this._sendUserDataKeepAlive(binanceRest, response), interval);
+            this.userDataRefreshIntervalId = setInterval(
+                () => this._sendUserDataKeepAlive(binanceRest, response),
+                interval
+            );
             this.userDataRefreshIntervalId.failCount = 0;
 
             return this._setupWebSocket(eventHandler, response.listenKey);

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -3,6 +3,7 @@ const Beautifier = require('./beautifier.js');
 const _ = require('underscore');
 
 class BinanceWS {
+
     constructor(beautify = true) {
         this._baseUrl = 'wss://stream.binance.com:9443/ws/';
         this._combinedBaseUrl = 'wss://stream.binance.com:9443/stream?streams=';
@@ -11,16 +12,17 @@ class BinanceWS {
         this._beautify = beautify;
 
         this.streams = {
-            depth: symbol => `${symbol.toLowerCase()}@depth`,
-            depthLevel: (symbol, level) =>
-                `${symbol.toLowerCase()}@depth${level}`,
-            kline: (symbol, interval) =>
-                `${symbol.toLowerCase()}@kline_${interval}`,
-            aggTrade: symbol => `${symbol.toLowerCase()}@aggTrade`,
-            trade: symbol => `${symbol.toLowerCase()}@trade`,
-            ticker: symbol => `${symbol.toLowerCase()}@ticker`,
+            depth: (symbol) => `${symbol.toLowerCase()}@depth`,
+            depthLevel: (symbol, level) => `${symbol.toLowerCase()}@depth${level}`,
+            kline: (symbol, interval) => `${symbol.toLowerCase()}@kline_${interval}`,
+            aggTrade: (symbol) => `${symbol.toLowerCase()}@aggTrade`,
+            trade: (symbol) => `${symbol.toLowerCase()}@trade`,
+            ticker: (symbol) => `${symbol.toLowerCase()}@ticker`,
             allTickers: () => '!ticker@arr'
         };
+
+        // when the user data stream is active, this will store a reference to the timer sending refresh requests.
+        this.userDataRefreshIntervalId;
     }
 
     _setupWebSocket(eventHandler, path, isCombined) {
@@ -69,29 +71,25 @@ class BinanceWS {
         return data;
     }
 
+    _clearUserDataInterval() {
+        this.userDataRefreshIntervalId && clearInterval(this.userDataRefreshIntervalId);
+        this.userDataRefreshIntervalId = false;
+    }
+
     onDepthUpdate(symbol, eventHandler) {
         return this._setupWebSocket(eventHandler, this.streams.depth(symbol));
     }
 
     onDepthLevelUpdate(symbol, level, eventHandler) {
-        return this._setupWebSocket(
-            eventHandler,
-            this.streams.depthLevel(symbol, level)
-        );
+        return this._setupWebSocket(eventHandler, this.streams.depthLevel(symbol, level));
     }
 
     onKline(symbol, interval, eventHandler) {
-        return this._setupWebSocket(
-            eventHandler,
-            this.streams.kline(symbol, interval)
-        );
+        return this._setupWebSocket(eventHandler, this.streams.kline(symbol, interval));
     }
 
     onAggTrade(symbol, eventHandler) {
-        return this._setupWebSocket(
-            eventHandler,
-            this.streams.aggTrade(symbol)
-        );
+        return this._setupWebSocket(eventHandler, this.streams.aggTrade(symbol));
     }
 
     onTrade(symbol, eventHandler) {
@@ -107,10 +105,23 @@ class BinanceWS {
     }
 
     onUserData(binanceRest, eventHandler, interval = 60000) {
+        this._clearUserDataInterval();
         return binanceRest.startUserDataStream().then(response => {
-            setInterval(() => {
-                binanceRest.keepAliveUserDataStream(response);
+
+            this.userDataRefreshIntervalId = setInterval(() => {
+                console.log(new Date(), 'onUserData() keep alive tick');
+                binanceRest.keepAliveUserDataStream(response).catch(e => {
+                    this.userDataRefreshIntervalId.failCount++;
+                    const msg = 'Failed requesting keepAliveUserDataStream for onUserData listener';
+                    if (e && e.code === -1125) {
+                        console.error(new Date(), msg + ' listen key expired - clearing keepAlive interval', e);
+                        return this._clearUserDataInterval();
+                    }
+                    return console.error(new Date(), msg, e, 'failCount: ', this.userDataRefreshIntervalId.failCount);
+                });
             }, interval);
+            this.userDataRefreshIntervalId.failCount = 0;
+
             return this._setupWebSocket(eventHandler, response.listenKey);
         });
     }

--- a/lib/ws.js
+++ b/lib/ws.js
@@ -21,7 +21,7 @@ class BinanceWS {
             allTickers: () => '!ticker@arr'
         };
 
-        // when the user data stream is active, this will store a reference to the timer sending refresh requests.
+        // Reference to the setInterval timer for sending keep alive requests in onUserData
         this.userDataRefreshIntervalId;
     }
 
@@ -76,6 +76,18 @@ class BinanceWS {
         this.userDataRefreshIntervalId = false;
     }
 
+    _sendUserDataKeepAlive(binanceRest, response) {
+        return binanceRest.keepAliveUserDataStream(response).catch(e => {
+            this.userDataRefreshIntervalId.failCount++;
+            const msg = 'Failed requesting keepAliveUserDataStream for onUserData listener';
+            if (e && e.code === -1125) {
+                console.error(new Date(), msg + ' listen key expired - clearing keepAlive interval', e);
+                return this._clearUserDataInterval();
+            }
+            return console.error(new Date(), msg, e, 'failCount: ', this.userDataRefreshIntervalId.failCount);
+        });
+    }
+
     onDepthUpdate(symbol, eventHandler) {
         return this._setupWebSocket(eventHandler, this.streams.depth(symbol));
     }
@@ -107,19 +119,7 @@ class BinanceWS {
     onUserData(binanceRest, eventHandler, interval = 60000) {
         this._clearUserDataInterval();
         return binanceRest.startUserDataStream().then(response => {
-
-            this.userDataRefreshIntervalId = setInterval(() => {
-                console.log(new Date(), 'onUserData() keep alive tick');
-                binanceRest.keepAliveUserDataStream(response).catch(e => {
-                    this.userDataRefreshIntervalId.failCount++;
-                    const msg = 'Failed requesting keepAliveUserDataStream for onUserData listener';
-                    if (e && e.code === -1125) {
-                        console.error(new Date(), msg + ' listen key expired - clearing keepAlive interval', e);
-                        return this._clearUserDataInterval();
-                    }
-                    return console.error(new Date(), msg, e, 'failCount: ', this.userDataRefreshIntervalId.failCount);
-                });
-            }, interval);
+            this.userDataRefreshIntervalId = setInterval(() => this._sendUserDataKeepAlive(binanceRest, response), interval);
             this.userDataRefreshIntervalId.failCount = 0;
 
             return this._setupWebSocket(eventHandler, response.listenKey);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "cover": "nyc --reporter=html --reporter=text mocha",
         "coveralls": "nyc report --reporter=text-lcov | coveralls",
         "lint": "eslint lib test util && prettier --check lib/**/* test/**/* util/**/*",
+        "lintfix": "eslint lib test util --fix && prettier --write lib/**/* test/**/* util/**/*",
         "precommit": "yarn test && yarn lint"
     },
     "dependencies": {

--- a/test/tests.js
+++ b/test/tests.js
@@ -205,8 +205,7 @@ describe('BinanceRest', () => {
                 (options, callback) => {
                     expect(options).to.deep.equal({
                         timeout: 15000,
-                        url:
-                            `${binance.getBaseUrl()}api/v1/ticker/allBookTickers`
+                        url: `${binance.getBaseUrl()}api/v1/ticker/allBookTickers`
                     });
                     callback(
                         null,
@@ -403,8 +402,7 @@ describe('BinanceRest', () => {
                     expect(options).to.deep.equal({
                         headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                         timeout: 15000,
-                        url:
-                            `${binance.getBaseUrl()}api/v1/historicalTrades?symbol=ETHBTC`
+                        url: `${binance.getBaseUrl()}api/v1/historicalTrades?symbol=ETHBTC`
                     });
                     callback(
                         null,
@@ -447,8 +445,7 @@ describe('BinanceRest', () => {
             mockRequest.setHandler('api/v1/aggTrades', (options, callback) => {
                 expect(options).to.deep.equal({
                     timeout: 15000,
-                    url:
-                        `${binance.getBaseUrl()}api/v1/aggTrades?symbol=ETHBTC`
+                    url: `${binance.getBaseUrl()}api/v1/aggTrades?symbol=ETHBTC`
                 });
                 callback(
                     null,
@@ -661,8 +658,7 @@ describe('BinanceRest', () => {
             mockRequest.setHandler('api/v1/klines', (options, callback) => {
                 expect(options).to.deep.equal({
                     timeout: 15000,
-                    url:
-                        `${binance.getBaseUrl()}api/v1/klines?symbol=ETHBTC&interval=1m&limit=5`
+                    url: `${binance.getBaseUrl()}api/v1/klines?symbol=ETHBTC&interval=1m&limit=5`
                 });
                 callback(
                     null,
@@ -758,8 +754,7 @@ describe('BinanceRest', () => {
                 (options, callback) => {
                     expect(options).to.deep.equal({
                         timeout: 15000,
-                        url:
-                            `${binance.getBaseUrl()}api/v1/ticker/24hr?symbol=ETHBTC`
+                        url: `${binance.getBaseUrl()}api/v1/ticker/24hr?symbol=ETHBTC`
                     });
                     callback(
                         null,
@@ -796,8 +791,7 @@ describe('BinanceRest', () => {
                 (options, callback) => {
                     expect(options).to.deep.equal({
                         timeout: 15000,
-                        url:
-                            `${binance.getBaseUrl()}api/v3/ticker/price?symbol=ETHBTC`
+                        url: `${binance.getBaseUrl()}api/v3/ticker/price?symbol=ETHBTC`
                     });
                     callback(
                         null,
@@ -820,8 +814,7 @@ describe('BinanceRest', () => {
                 (options, callback) => {
                     expect(options).to.deep.equal({
                         timeout: 15000,
-                        url:
-                            `${binance.getBaseUrl()}api/v3/ticker/bookTicker?symbol=ETHBTC`
+                        url: `${binance.getBaseUrl()}api/v3/ticker/bookTicker?symbol=ETHBTC`
                     });
                     callback(
                         null,
@@ -858,8 +851,7 @@ describe('BinanceRest', () => {
                     headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                     method: 'POST',
                     timeout: 30000,
-                    url:
-                        `${binance.getBaseUrl()}api/v3/order?symbol=BNBBTC&side=SELL&type=LIMIT&timeInForce=GTC&quantity=5&price=0.000635&timestamp=1503258350918&recvWindow=10000&signature=6c9f93d8c10c73b0bb5ff527b8f28696d7b2ef32e404da362b7eb99ee09d3832`
+                    url: `${binance.getBaseUrl()}api/v3/order?symbol=BNBBTC&side=SELL&type=LIMIT&timeInForce=GTC&quantity=5&price=0.000635&timestamp=1503258350918&recvWindow=10000&signature=6c9f93d8c10c73b0bb5ff527b8f28696d7b2ef32e404da362b7eb99ee09d3832`
                 });
                 callback(
                     null,
@@ -893,8 +885,7 @@ describe('BinanceRest', () => {
                     headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                     method: 'POST',
                     timeout: 30000,
-                    url:
-                        `${binance.getBaseUrl()}api/v3/order/test?symbol=BNBBTC&side=SELL&type=LIMIT&timeInForce=GTC&quantity=5&price=0.000635&timestamp=1503258350918&recvWindow=10000&signature=6c9f93d8c10c73b0bb5ff527b8f28696d7b2ef32e404da362b7eb99ee09d3832`
+                    url: `${binance.getBaseUrl()}api/v3/order/test?symbol=BNBBTC&side=SELL&type=LIMIT&timeInForce=GTC&quantity=5&price=0.000635&timestamp=1503258350918&recvWindow=10000&signature=6c9f93d8c10c73b0bb5ff527b8f28696d7b2ef32e404da362b7eb99ee09d3832`
                 });
                 callback(null, { statusCode: 200 }, '{}');
             });
@@ -918,8 +909,7 @@ describe('BinanceRest', () => {
                 expect(options).to.deep.equal({
                     headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                     timeout: 30000,
-                    url:
-                        `${binance.getBaseUrl()}api/v3/order?symbol=BNBBTC&orderId=1497927&timestamp=0&recvWindow=10000&signature=ce8c5519ee23564230f08db5b3248894a17952049f675ee37d09ad8933868bd1`
+                    url: `${binance.getBaseUrl()}api/v3/order?symbol=BNBBTC&orderId=1497927&timestamp=0&recvWindow=10000&signature=ce8c5519ee23564230f08db5b3248894a17952049f675ee37d09ad8933868bd1`
                 });
                 callback(
                     null,
@@ -956,8 +946,7 @@ describe('BinanceRest', () => {
                 expect(options).to.deep.equal({
                     headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                     timeout: 30000,
-                    url:
-                        `${binance.getBaseUrl()}api/v3/openOrders?symbol=BNBBTC&timestamp=0&recvWindow=10000&signature=54dfa6e974bfcd0c2bcdddd65e820fd16b05515dfc66f5033b0fbffe9f9daca2`
+                    url: `${binance.getBaseUrl()}api/v3/openOrders?symbol=BNBBTC&timestamp=0&recvWindow=10000&signature=54dfa6e974bfcd0c2bcdddd65e820fd16b05515dfc66f5033b0fbffe9f9daca2`
                 });
                 callback(
                     null,
@@ -992,8 +981,7 @@ describe('BinanceRest', () => {
                     headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                     method: 'DELETE',
                     timeout: 30000,
-                    url:
-                        `${binance.getBaseUrl()}api/v3/order?symbol=BNBBTC&orderId=1500955&timestamp=0&recvWindow=10000&signature=9546f891b4a19fdf87c1913fa04020113fdd1ec04cfaf4c2aac157fec2857025`
+                    url: `${binance.getBaseUrl()}api/v3/order?symbol=BNBBTC&orderId=1500955&timestamp=0&recvWindow=10000&signature=9546f891b4a19fdf87c1913fa04020113fdd1ec04cfaf4c2aac157fec2857025`
                 });
                 callback(
                     null,
@@ -1021,8 +1009,7 @@ describe('BinanceRest', () => {
                 expect(options).to.deep.equal({
                     headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                     timeout: 30000,
-                    url:
-                        `${binance.getBaseUrl()}api/v3/allOrders?symbol=BNBBTC&timestamp=0&recvWindow=10000&signature=54dfa6e974bfcd0c2bcdddd65e820fd16b05515dfc66f5033b0fbffe9f9daca2`
+                    url: `${binance.getBaseUrl()}api/v3/allOrders?symbol=BNBBTC&timestamp=0&recvWindow=10000&signature=54dfa6e974bfcd0c2bcdddd65e820fd16b05515dfc66f5033b0fbffe9f9daca2`
                 });
                 callback(
                     null,
@@ -1056,8 +1043,7 @@ describe('BinanceRest', () => {
                 expect(options).to.deep.equal({
                     headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                     timeout: 30000,
-                    url:
-                        `${binance.getBaseUrl()}api/v3/account?timestamp=0&recvWindow=10000&signature=fa83689730fa7ac8f7c2e24a10b0fa8baf0503756158128cced2e355934b5140`
+                    url: `${binance.getBaseUrl()}api/v3/account?timestamp=0&recvWindow=10000&signature=fa83689730fa7ac8f7c2e24a10b0fa8baf0503756158128cced2e355934b5140`
                 });
                 callback(
                     null,
@@ -1200,8 +1186,7 @@ describe('BinanceRest', () => {
                 expect(options).to.deep.equal({
                     headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                     timeout: 30000,
-                    url:
-                        `${binance.getBaseUrl()}api/v3/myTrades?symbol=BNBBTC&timestamp=0&recvWindow=10000&signature=54dfa6e974bfcd0c2bcdddd65e820fd16b05515dfc66f5033b0fbffe9f9daca2`
+                    url: `${binance.getBaseUrl()}api/v3/myTrades?symbol=BNBBTC&timestamp=0&recvWindow=10000&signature=54dfa6e974bfcd0c2bcdddd65e820fd16b05515dfc66f5033b0fbffe9f9daca2`
                 });
                 callback(
                     null,
@@ -1233,8 +1218,7 @@ describe('BinanceRest', () => {
                     expect(options).to.deep.equal({
                         headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                         timeout: 30000,
-                        url:
-                            `${binance.getBaseUrl()}wapi/v3/accountStatus.html?timestamp=0&recvWindow=10000&signature=fa83689730fa7ac8f7c2e24a10b0fa8baf0503756158128cced2e355934b5140`
+                        url: `${binance.getBaseUrl()}wapi/v3/accountStatus.html?timestamp=0&recvWindow=10000&signature=fa83689730fa7ac8f7c2e24a10b0fa8baf0503756158128cced2e355934b5140`
                     });
                     callback(
                         null,
@@ -1259,8 +1243,7 @@ describe('BinanceRest', () => {
                         method: 'POST',
                         headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                         timeout: 30000,
-                        url:
-                            `${binance.getBaseUrl()}wapi/v3/withdraw.html?asset=ETH&address=0x000&amount=Bajillions&timestamp=0&recvWindow=10000&signature=5eb0f5626cfdfc1f1b4681071fc4080180832aae4739fe4cadb92e153dbbc525`
+                        url: `${binance.getBaseUrl()}wapi/v3/withdraw.html?asset=ETH&address=0x000&amount=Bajillions&timestamp=0&recvWindow=10000&signature=5eb0f5626cfdfc1f1b4681071fc4080180832aae4739fe4cadb92e153dbbc525`
                     });
                     callback(
                         null,
@@ -1291,8 +1274,7 @@ describe('BinanceRest', () => {
                     expect(options).to.deep.equal({
                         headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                         timeout: 30000,
-                        url:
-                            `${binance.getBaseUrl()}wapi/v3/depositHistory.html?asset=ETH&timestamp=0&recvWindow=10000&signature=adb0f32f3ef4b9116b17ae095371ede1e97ffe9447bfb1e88f78285426ac615b`
+                        url: `${binance.getBaseUrl()}wapi/v3/depositHistory.html?asset=ETH&timestamp=0&recvWindow=10000&signature=adb0f32f3ef4b9116b17ae095371ede1e97ffe9447bfb1e88f78285426ac615b`
                     });
                     callback(
                         null,
@@ -1327,8 +1309,7 @@ describe('BinanceRest', () => {
                     expect(options).to.deep.equal({
                         headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                         timeout: 30000,
-                        url:
-                            `${binance.getBaseUrl()}wapi/v3/withdrawHistory.html?asset=ETH&timestamp=0&recvWindow=10000&signature=adb0f32f3ef4b9116b17ae095371ede1e97ffe9447bfb1e88f78285426ac615b`
+                        url: `${binance.getBaseUrl()}wapi/v3/withdrawHistory.html?asset=ETH&timestamp=0&recvWindow=10000&signature=adb0f32f3ef4b9116b17ae095371ede1e97ffe9447bfb1e88f78285426ac615b`
                     });
                     callback(
                         null,
@@ -1364,8 +1345,7 @@ describe('BinanceRest', () => {
                     expect(options).to.deep.equal({
                         headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                         timeout: 30000,
-                        url:
-                            `${binance.getBaseUrl()}wapi/v3/depositAddress.html?asset=BNB&timestamp=0&recvWindow=10000&signature=d00b9bc06f44f2336cfbbf2f4216a36e3c8c9b10a3d110fb733966bb9c7c8e1e`
+                        url: `${binance.getBaseUrl()}wapi/v3/depositAddress.html?asset=BNB&timestamp=0&recvWindow=10000&signature=d00b9bc06f44f2336cfbbf2f4216a36e3c8c9b10a3d110fb733966bb9c7c8e1e`
                     });
                     callback(
                         null,
@@ -1428,8 +1408,7 @@ describe('BinanceRest', () => {
                         headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                         method: 'PUT',
                         timeout: 30000,
-                        url:
-                            `${binance.getBaseUrl()}api/v1/userDataStream?listenKey=DdfvqZ427zcWvtOzBSxmchhHPKV1t0lVCHdztRjIdU7CygJckPIIYmx5TOqU`
+                        url: `${binance.getBaseUrl()}api/v1/userDataStream?listenKey=DdfvqZ427zcWvtOzBSxmchhHPKV1t0lVCHdztRjIdU7CygJckPIIYmx5TOqU`
                     });
                     callback(null, { statusCode: 200 }, '{}');
                 }
@@ -1452,8 +1431,7 @@ describe('BinanceRest', () => {
                         headers: { 'X-MBX-APIKEY': 'super_secret_api_key' },
                         method: 'DELETE',
                         timeout: 30000,
-                        url:
-                            `${binance.getBaseUrl()}api/v1/userDataStream?listenKey=DdfvqZ427zcWvtOzBSxmchhHPKV1t0lVCHdztRjIdU7CygJckPIIYmx5TOqU`
+                        url: `${binance.getBaseUrl()}api/v1/userDataStream?listenKey=DdfvqZ427zcWvtOzBSxmchhHPKV1t0lVCHdztRjIdU7CygJckPIIYmx5TOqU`
                     });
                     callback(null, { statusCode: 200 }, '{}');
                 }


### PR DESCRIPTION
This PR addresses two scenarios.

1. A userData websocket connection is opened and closed deliberately. The current design causes the module to keep sending keep alive requests indefinitely. See #70 
2. A network issue caused the websocket to drop, which is easily handled by opening a new connection. The old listen key expires, yet the old logic keeps sending keep alive requests indefinitely. Over time this can quickly multiply at many overlapping keep alive requests putting pressure on the rate limits with binance's APIs.

Key changes:
- The keepAlive timer interval is stored.
- A new call to onUserData clears an old interval if one is found.
- If a keep alive request sees an error code indicating the listen key is no longer valid, the keep alive timer is cleared (as the websocket already closed too - this is purely a cleanup operation).
  - In the old logic, this error would repeatedly spam the console over time: 
```
{ code: -1125, msg: 'This listenKey does not exist.' }
```

This is working well for me. The listen key expires after an hour, and this logic detects the expired/invalid key and stops sending keep alive requests.