### PR TITLE
FIXED typo in lib/beautifier.js

### DIFF
--- a/lib/beautifier.js
+++ b/lib/beautifier.js
@@ -212,7 +212,7 @@ class Beautifier {
                     });
                 } else {
                     _.each(value, (arrayValue, arrayKey) => {
-                        newItem.push(
+                        newArray.push(
                             this.beautify(value, beautifications[arrayKey])
                         );
                     });


### PR DESCRIPTION
**Summary**

- `newItem` is initialized as an array and then the push method is called on it. This is a typo and it should read `newArray.push`.  
- I changed `newItem.push` to `newArray.push` @ line 215 in `lib/beautifier.js` to fix `TypeError: newItem.push is not a function`.