### PR TITLE
Supports the handling of event type "outboundAccountPosition" in user data stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -651,15 +651,14 @@ Responses
             onOrderBalance: '0.00000000'
         },
         {
-          asset: 'BNB',
-          availableBalance: '0.00032331',
-          onOrderBalance: '0.00000000'
+            asset: 'BNB',
+            availableBalance: '0.00032331',
+            onOrderBalance: '0.00000000'
         },
         ... 
     ]
 }
 ```
-
 
 # Processing
 

--- a/README.md
+++ b/README.md
@@ -645,17 +645,18 @@ Responses
     eventTime: 1513808673916,
     lastUpdateTime: 1499405658848,
     balances: [
-    {
-        asset: 'BTC',
-        availableBalance: '0.00301025',
-        onOrderBalance: '0.00000000'
-    },
-    {
-      asset: 'BNB',
-      availableBalance: '0.00032331',
-      onOrderBalance: '0.00000000'
-    },
-    ... 
+        {
+            asset: 'BTC',
+            availableBalance: '0.00301025',
+            onOrderBalance: '0.00000000'
+        },
+        {
+          asset: 'BNB',
+          availableBalance: '0.00032331',
+          onOrderBalance: '0.00000000'
+        },
+        ... 
+    ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -639,6 +639,27 @@ Responses
 }
 ```
 
+```javascript
+{
+    eventType: 'outboundAccountPosition',
+    eventTime: 1513808673916,
+    lastUpdateTime: 1499405658848,
+    balances: [
+    {
+        asset: 'BTC',
+        availableBalance: '0.00301025',
+        onOrderBalance: '0.00000000'
+    },
+    {
+      asset: 'BNB',
+      availableBalance: '0.00032331',
+      onOrderBalance: '0.00000000'
+    },
+    ... 
+}
+```
+
+
 # Processing
 
 ## Filters

--- a/lib/beautifier.js
+++ b/lib/beautifier.js
@@ -115,6 +115,12 @@ class Beautifier {
                 B: 'balances',
                 u: 'lastUpdateTime'
             },
+            outboundAccountPositionEvent : {
+                e: 'eventType',
+                E: 'eventTime',
+                u: 'lastUpdateTime',
+                B: 'balances'
+            },
             balances: [
                 {
                     a: 'asset',

--- a/lib/beautifier.js
+++ b/lib/beautifier.js
@@ -115,7 +115,7 @@ class Beautifier {
                 B: 'balances',
                 u: 'lastUpdateTime'
             },
-            outboundAccountPositionEvent : {
+            outboundAccountPositionEvent: {
                 e: 'eventType',
                 E: 'eventTime',
                 u: 'lastUpdateTime',


### PR DESCRIPTION
Supports the handling of event type ```outboundAccountPosition```  for the user data stream (onUserData).

This event is similar to the ```outboundAccountInfo``` event type but is more compact and only gives the affected balances. 

```javascript
{
  "e": "outboundAccountPosition", 
  "E": 1564034571105,                 
  "u": 1564034571073,            
  "B": [                                        
    {
      "a": "ETH",                         
      "f": "10000.000000",            
      "l": "0.000000"  
    }
  ]
}
```

This event type was introduced in 2019-09-15 and described at https://binance-docs.github.io/apidocs/spot/en/#change-log:

> New Event Type ```outboundAccountPosition```; ```outboundAccountPosition``` is sent any time an account's balance changes and contains the assets that could have changed by the event that generated the balance change (a deposit, withdrawal, trade, order placement, or cancelation).